### PR TITLE
Codex/final launch prep

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -35,6 +35,7 @@ This runs:
 - model evaluation
 - GenAI brief generation from the bundled sample brief
 - optional concept image generation in mock mode for the saved sample campaign
+- campaign export ZIP generation for the latest saved campaign
 
 Demo outputs are collected under:
 
@@ -43,6 +44,7 @@ demo_outputs/latest/
 ```
 
 This bundle includes the latest model outputs plus the saved GenAI brief artifacts under `demo_outputs/latest/genai/`.
+It also includes the latest exported campaign ZIP for download or handoff.
 
 ## Local App Runs
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -10,6 +10,7 @@ This list reflects functionality that is already present in the repository.
 - Model evaluation and metrics export
 - GenAI brief copilot for campaign summaries, personas, angles, copy variants, CTA variants, and image prompts
 - Optional image concept generation with saved per-campaign assets and metadata
+- Approval and rejection states for saved generated images
 - FastAPI service with health and customer endpoints
 - Streamlit dashboard for data review and demo presentation
 
@@ -31,6 +32,7 @@ This list reflects functionality that is already present in the repository.
 - One-command local demo path
 - Mock-first local GenAI mode with optional live provider configuration
 - Streamlit gallery flow for selecting saved campaigns, prompts, and generated image concepts
+- Campaign history, regeneration controls, and export ZIP workflow
 - Setup script and Makefile shortcuts
 - Sample raw input data included in the repository
 - Buyer-facing overview and demo documentation

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python
 
-.PHONY: setup demo genai-demo genai-image-demo test train evaluate api dashboard run-dashboard airflow
+.PHONY: setup demo genai-demo genai-image-demo genai-export-demo test train evaluate api dashboard run-dashboard airflow
 
 setup:
 	./setup.sh
@@ -13,6 +13,9 @@ genai-demo:
 
 genai-image-demo:
 	$(PYTHON) -m genai.image_demo --campaign-id $$(ls -1t data/generated/manifests/*.json | head -n 1 | xargs basename | sed 's/\.json$$//')
+
+genai-export-demo:
+	$(PYTHON) -m genai.export_demo --campaign-id $$(ls -1t data/generated/manifests/*.json | head -n 1 | xargs basename | sed 's/\.json$$//')
 
 test:
 	$(PYTHON) -m pytest tests/

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -25,6 +25,7 @@ It is not positioned as a finished SaaS product or managed hosted service.
 - Scikit-learn training and evaluation flow
 - GenAI brief copilot for campaign summaries, personas, channel suggestions, copy variants, CTA variants, and image prompts
 - Optional image concept generation from saved prompts, with local mock mode for demos
+- Workflow controls for regeneration, image approvals, saved history, and campaign export ZIPs
 - FastAPI application with lightweight customer endpoints
 - Streamlit dashboard for stakeholder-friendly presentation
 - CRM integration examples for Salesforce and HubSpot

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -8,6 +8,7 @@
 
 - A Python marketing workflow codebase covering ingestion, transformation, modeling, and presentation
 - A GenAI layer that turns campaign briefs into structured copy outputs and concept-image prompts
+- Workflow controls for regeneration, image approvals, campaign history, and export bundles
 - A FastAPI service for exposing customer-facing or internal scoring endpoints
 - A Streamlit dashboard for stakeholder-friendly reporting and CRM workflow demos
 - Airflow DAGs, Dockerfiles, and Kubernetes manifests to support deployment conversations

--- a/QA_CHECKLIST.md
+++ b/QA_CHECKLIST.md
@@ -1,0 +1,60 @@
+# QA Checklist
+
+Use this checklist before the first public sale or before packaging a new release.
+
+## Install
+
+- `make setup` completes on a clean machine
+- local `.venv` is created successfully
+- required Python packages install without manual fixes
+- `.env.example` is sufficient for a safe local start
+
+## Tests
+
+- `python -m pytest tests/` runs successfully
+- FastAPI tests pass
+- GenAI workflow tests pass
+- no unexpected import errors appear in the active Python version
+
+## Demo
+
+- `make demo` completes from a clean repo checkout
+- `demo_outputs/latest/` is created
+- `demo_outputs/latest/genai/` contains brief, copy, and export artifacts
+- `demo_outputs/latest/genai/images/` contains concept image files and image metadata
+
+## Streamlit
+
+- `make dashboard` launches successfully
+- the dashboard hero renders correctly
+- the Brief Copilot form generates a saved campaign
+- the Campaign History panel lists saved campaigns
+- the Image Concepts panel generates mock images
+- approve / reject / reset actions update image statuses
+- export ZIP can be built and downloaded
+
+## FastAPI
+
+- `make api` launches successfully
+- `GET /health` returns `200`
+- `GET /customers` returns sample or real data
+- `POST /genai/brief` returns a saved campaign manifest
+- `POST /genai/images` returns saved image metadata
+- `POST /genai/campaigns/{campaign_id}/images/review` updates approval state
+- `GET /genai/campaigns/{campaign_id}/export` returns a ZIP file
+
+## Export
+
+- exported ZIP opens cleanly
+- ZIP contains `brief.json`
+- ZIP contains `copy.json`
+- ZIP contains `prompts.json`
+- ZIP contains `manifest.json`
+- ZIP contains `images/` with generated assets when available
+
+## Release Surface
+
+- README matches the shipped workflow
+- product docs do not overclaim unsupported features
+- screenshots and GIF reflect the current UI
+- no generated runtime clutter is tracked in git

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ CampaignForge AI is a production-style Python workflow for buyers who want a cre
 - Trains and evaluates a scikit-learn classification model for lead-scoring and campaign analytics style use cases
 - Generates campaign summaries, audience suggestions, copy variants, CTA variants, and image prompts from a structured brief
 - Generates optional concept images from saved campaign prompts with mock mode by default and live provider mode when configured
+- Tracks approval state for generated images, supports regeneration, and exports full campaign bundles as ZIP files
 - Exposes lightweight customer endpoints through FastAPI
 - Presents customer data, GenAI brief outputs, and CRM handoff workflows through Streamlit
 - Includes Airflow, Docker, and Kubernetes assets to support operational and deployment discussions
@@ -29,6 +30,7 @@ CampaignForge AI is a production-style Python workflow for buyers who want a cre
 - ETL scripts, model training, and model evaluation workflow
 - GenAI brief copilot package with mock-first and API-key-gated live modes
 - Optional image generation layer that saves assets and metadata per campaign
+- Workflow controls for campaign history, regeneration, image review, and bundle export
 - FastAPI service and Streamlit dashboard
 - CRM integration examples for Salesforce and HubSpot
 - Google Sheets sync example
@@ -45,6 +47,7 @@ CampaignForge AI is a production-style Python workflow for buyers who want a cre
 - Full Python source code for ETL, model training, evaluation, API delivery, and dashboard presentation
 - GenAI brief-to-copy workflow with saved JSON outputs under `data/generated/`
 - Structured image generation folders under `data/generated/images/<campaign_id>/`
+- Exported campaign ZIP bundles under `data/generated/exports/`
 - Demo data, predictable demo outputs, and Makefile shortcuts
 - FastAPI and Streamlit interfaces for technical and non-technical walkthroughs
 - Docker, Kubernetes, and Airflow assets for packaging and operations discussions
@@ -62,6 +65,7 @@ What those commands do:
 
 - `make demo`: bootstraps the local environment if needed, then runs ETL, model training, evaluation, and the GenAI brief copilot end-to-end using the included sample inputs
 - when dependencies are installed, `make demo` also generates saved concept images in mock mode for the latest campaign brief
+- `make demo` also writes an exportable ZIP bundle for the latest generated campaign
 
 The bundled demo inputs are included under `data/raw/` and `data/demo/`.
 
@@ -78,6 +82,7 @@ That folder contains:
 - the evaluation metrics JSON
 - a `genai/` folder containing the latest saved campaign brief manifest and copy output
 - saved image concept assets and metadata for the latest generated campaign
+- an exported campaign ZIP ready for download or handoff
 - a small readme for quick inspection
 
 If you want to continue the full interactive walkthrough after the demo run:
@@ -111,8 +116,9 @@ Recommended buyer demo flow:
 2. Open `demo_outputs/latest/` and review the generated outputs
 3. Review the generated campaign brief outputs under `demo_outputs/latest/genai/`
 4. Review the saved concept images under `demo_outputs/latest/genai/images/`
-5. Launch the API with `make api`
-6. Launch the dashboard with `make dashboard`
+5. Download or inspect the exported campaign ZIP in `demo_outputs/latest/genai/`
+6. Launch the API with `make api`
+7. Launch the dashboard with `make dashboard`
 
 Useful companion docs:
 
@@ -176,6 +182,7 @@ project-root/
 | Source code | Yes |
 | Local run path | Yes |
 | One-command demo | Yes |
+| Campaign export ZIP | Yes |
 | Docker support | Yes |
 | Dashboard | Yes |
 | API | Yes |
@@ -189,6 +196,7 @@ project-root/
 - Generated outputs such as model artifacts, processed data, and local runtime files are intentionally gitignored.
 - Demo outputs are collected under `demo_outputs/latest/` for predictable review.
 - Generated GenAI artifacts are saved under `data/generated/` and copied into the demo output bundle.
+- Streamlit now includes saved campaign history plus workflow controls for regeneration, image review, and export.
 - `streamlit_app.py` is the single supported dashboard entrypoint for demos and local runs.
 - Local secrets should be supplied through `.env` and `.streamlit/secrets.toml`; start from `.env.example` where applicable.
 - Set `CAMPAIGNFORGE_LLM_PROVIDER=openai` and `OPENAI_API_KEY` only when you want live LLM output; the local default is mock mode.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Turn campaign briefs and customer data into reusable strategy, copy, API respons
 
 CampaignForge AI is a production-style Python workflow for buyers who want a credible campaign intelligence demo or starter product. It packages ETL, lead-scoring style modeling, a GenAI brief copilot, API delivery, dashboard presentation, and deployment assets into one reviewable repository. It is not positioned as a hosted SaaS product or a finished image-generation platform.
 
+## Product Workflow
+
+CampaignForge AI is designed around a simple workflow:
+
+1. Brief
+   Capture a structured campaign brief with product, audience, channel, and tone inputs.
+2. Strategy
+   Generate a campaign summary, personas, channel recommendations, and campaign angles.
+3. Copy
+   Produce headline variants, body copy variants, CTA options, and prompt-ready messaging.
+4. Image Concepts
+   Turn saved prompts into mock-first concept images or live-provider outputs when configured.
+5. Review
+   Revisit saved campaigns, regenerate copy or prompts, and approve or reject generated images.
+6. Export
+   Download a ZIP bundle containing the brief, copy, prompts, manifests, and saved images.
+
 ## What It Does
 
 - Processes raw campaign and customer data into cleaned, analysis-ready datasets
@@ -120,6 +137,15 @@ Recommended buyer demo flow:
 6. Launch the API with `make api`
 7. Launch the dashboard with `make dashboard`
 
+Recommended public sale narrative:
+
+- Brief: enter a campaign concept and target market
+- Strategy: review the generated campaign summary and angle options
+- Copy: inspect headlines, body copy, CTAs, and saved prompts
+- Image Concepts: generate concept visuals from a selected angle
+- Review: approve or reject images, then regenerate where needed
+- Export: download the campaign ZIP bundle for handoff
+
 Useful companion docs:
 
 - `PROJECT_OVERVIEW.md` for a buyer-facing summary
@@ -129,6 +155,8 @@ Useful companion docs:
 - `docs/LISTING_COPY.md` for repo description and marketplace copy
 - `docs/ASSET_PREP.md` for screenshots, GIFs, and listing asset planning
 - `docs/GENAI_ROADMAP.md` for the staged GenAI plan
+- `QA_CHECKLIST.md` for launch verification
+- `RELEASE_NOTES.md` for the v1 sale-ready summary
 
 ## Project Structure
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -20,12 +20,16 @@ Use this checklist before publishing or selling the repository as a downloadable
 - `make setup` works on a clean machine
 - `make demo` completes successfully
 - `demo_outputs/latest/` contains expected files
+- `demo_outputs/latest/genai/` contains brief, copy, prompts, and export artifacts
+- `demo_outputs/latest/genai/images/` contains generated concept assets when image generation runs
 - `make api` launches successfully
 - `make dashboard` launches successfully
 
 ## Documentation
 
 - README is up to date
+- `QA_CHECKLIST.md` is current
+- `RELEASE_NOTES.md` is current
 - `PRODUCT.md` clearly explains buyer-facing value
 - `DEPLOYMENT.md` reflects the current local and Docker setup
 - `PROJECT_OVERVIEW.md` is aligned with the README
@@ -38,6 +42,7 @@ Use this checklist before publishing or selling the repository as a downloadable
 - API screenshot or sample response is ready
 - Model training/evaluation output screenshot is ready
 - GenAI brief and image concept screenshots are ready
+- workflow review/export screenshot or GIF moment is ready
 - `docs/assets/` contains the final screenshots or a clear asset plan
 - Screenshots do not expose usernames, tokens, or local machine paths
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,31 @@
+# Release Notes
+
+## v1.0.0
+
+CampaignForge AI is now packaged as a first-sale-ready downloadable developer product centered on a complete campaign workflow:
+
+- Brief capture with structured marketing inputs
+- Strategy generation with summaries, personas, channels, and campaign angles
+- Copy generation with headlines, body variants, CTAs, and image prompts
+- Optional image concept generation with mock-first local mode and swappable live-provider support
+- Review workflow with campaign history, regeneration controls, and image approval states
+- Campaign export as a ZIP bundle containing the brief, copy, prompts, manifests, and images
+
+### Delivery Surfaces
+
+- Streamlit dashboard for interactive demos
+- FastAPI endpoints for programmatic generation, retrieval, review, and export
+- One-command local demo flow via `make demo`
+
+### Packaging Improvements
+
+- sale-oriented README and supporting product docs
+- buyer-facing demo, listing, and asset prep materials
+- structured generated-output folders under `data/generated/`
+- repo cleanup and gitignore hardening for local/runtime artifacts
+
+### Notes
+
+- mock mode remains the default for local demos
+- live LLM and image generation require environment-variable configuration
+- the repository is positioned as a source-code product, not a hosted SaaS application

--- a/docs/ASSET_PREP.md
+++ b/docs/ASSET_PREP.md
@@ -4,8 +4,10 @@ Use this folder guidance when preparing screenshots, a short GIF, or marketplace
 
 ## Recommended Asset Set
 
-- `docs/assets/dashboard-home.png`
-- `docs/assets/demo-outputs.png`
+- `docs/assets/readme-hero-workflow.png`
+- `docs/assets/brief-copilot-results.png`
+- `docs/assets/image-concepts-gallery.png`
+- `docs/assets/export-workflow.png`
 - `docs/assets/api-response.png`
 - `docs/assets/quickstart.gif`
 - `docs/assets/what-you-get.png`
@@ -20,8 +22,9 @@ Use this folder guidance when preparing screenshots, a short GIF, or marketplace
 
 ## Suggested Visual Story
 
-1. Dashboard hero and KPI area
-2. Demo outputs folder with model and metrics files
-3. FastAPI response example
-4. One-command demo run in the terminal
-5. A simple "what you get" summary image for listings
+1. README hero and workflow promise
+2. Brief Copilot results with copy and prompt output
+3. Image Concepts gallery with saved concepts
+4. Review and export controls in the Campaign History panel
+5. FastAPI response example
+6. A simple "what you get" summary image for listings

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -60,6 +60,8 @@ Focus on:
 - hero/dashboard presentation
 - brief copilot output generation
 - image concept gallery for saved campaigns
+- approval/reject workflow on generated concepts
+- campaign ZIP export
 - sample customer dataset panel
 - CRM sync dry-run workflow
 

--- a/docs/GENAI_ROADMAP.md
+++ b/docs/GENAI_ROADMAP.md
@@ -31,16 +31,22 @@ Current scope:
 - mock SVG generation by default for local demos
 - optional OpenAI-compatible live image generation when environment variables are configured
 
-Still planned:
+Now available:
 
-- regenerate and approve/reject flows
+- regenerate controls for copy and prompts
+- approve, reject, and reset states for generated image concepts
 
 ## Phase 3: Workflow Product Polish
 
-Planned next steps:
+CampaignForge AI now also includes:
 
-- exportable campaign packs
+- exportable campaign ZIP bundles
 - saved campaign history and retrieval
+- regeneration controls for copy and prompts
+- approval and rejection states for generated image concepts
+
+Still planned:
+
 - reusable industry templates
 - tone presets and brand guardrails
 - basic auth if hosted

--- a/docs/SAMPLE_OUTPUTS.md
+++ b/docs/SAMPLE_OUTPUTS.md
@@ -73,6 +73,20 @@ Saved 2 assets in data/generated/images/campaignforge-product-launch-20260407143
 - manifest.json
 ```
 
+## Campaign Export Output
+
+```text
+campaignforge-product-launch-20260407143000.zip
+```
+
+```text
+brief.json
+copy.json
+prompts.json
+manifest.json
+images/
+```
+
 ## CRM Dry-Run Message
 
 ```text

--- a/docs/SCREENSHOT_CHECKLIST.md
+++ b/docs/SCREENSHOT_CHECKLIST.md
@@ -6,28 +6,30 @@ Use this checklist when preparing a marketplace listing, portfolio post, or buye
 
 - Repository landing page with project title and badges visible
 - README top section showing the value proposition
-- Architecture diagram section
+- README workflow section showing `Brief -> Strategy -> Copy -> Image Concepts -> Review -> Export`
 
 ## Terminal / Execution
 
-- `make setup` success output
-- ETL run output
-- `make train` output with successful completion
-- `make evaluate` output with metrics visible
+- `make demo` success output
+- `demo_outputs/latest/` folder view
+- generated export ZIP visible in `demo_outputs/latest/genai/`
 
 ## API
 
 - FastAPI `/health` response
 - FastAPI `/customers` response
+- FastAPI `/genai/brief` response
+- FastAPI export endpoint returning a ZIP file
 - Optional `/docs` page if enabled locally for demo purposes
 
 ## Dashboard
 
 - Full dashboard landing screen with hero section visible
-- Metric cards row
-- Dataset preview section
+- Brief Copilot output section with angles visible
+- Campaign History panel with regeneration and export controls
+- Image Concepts section with generated mock visuals visible
+- Approved or rejected image status visible
 - CRM sync panel in dry-run mode
-- Dry-run result message after action
 
 ## Ops / Delivery
 
@@ -41,3 +43,20 @@ Use this checklist when preparing a marketplace listing, portfolio post, or buye
 - Keep terminal output clean by using a fresh shell session
 - Use dry-run modes for integrations so screens remain safe to share
 - Avoid including local usernames, tokens, or machine-specific paths
+
+## Best Screenshot Moments
+
+1. README hero plus workflow section
+2. `make demo` finished successfully with the output folder visible
+3. Brief Copilot results with angles and copy variants open
+4. Image Concepts gallery with at least one approved asset
+5. Campaign History panel with the export control visible
+6. FastAPI JSON response for `/genai/brief` or `/health`
+
+## GIF Recommendation
+
+- Capture one short 20-30 second GIF showing:
+  - selecting a saved campaign
+  - generating image concepts
+  - approving one concept
+  - building and downloading the export ZIP

--- a/genai/export_demo.py
+++ b/genai/export_demo.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import argparse
+
+from genai.service import CampaignExportService
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export a CampaignForge AI campaign bundle.")
+    parser.add_argument("--campaign-id", required=True, help="Campaign id to export.")
+    args = parser.parse_args()
+
+    export_path = CampaignExportService().export_campaign(args.campaign_id)
+    print(f"Exported campaign bundle: {export_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/genai/schemas.py
+++ b/genai/schemas.py
@@ -48,11 +48,15 @@ class CampaignOutput(BaseModel):
 class SavedArtifact(BaseModel):
     manifest_path: str
     copy_output_path: str
+    brief_path: Optional[str] = None
+    prompts_path: Optional[str] = None
+    export_zip_path: Optional[str] = None
 
 
 class CampaignManifest(BaseModel):
     campaign_id: str
     created_at: str
+    updated_at: Optional[str] = None
     provider: str
     mode: str
     brief: CampaignBrief
@@ -76,14 +80,25 @@ class GeneratedImageAsset(BaseModel):
     mode: str
     file_path: str
     mime_type: str
+    approval_status: str = "pending"
 
 
 class ImageGenerationManifest(BaseModel):
     campaign_id: str
     angle_id: Optional[str] = None
     created_at: str
+    updated_at: Optional[str] = None
     provider: str
     mode: str
     style: str
     prompt: str
     assets: List[GeneratedImageAsset]
+
+
+class CampaignRegenerationRequest(BaseModel):
+    scope: str = Field(default="all", pattern="^(copy|prompts|all)$")
+
+
+class ImageReviewRequest(BaseModel):
+    image_id: str
+    approval_status: str = Field(pattern="^(approved|rejected|pending)$")

--- a/genai/service.py
+++ b/genai/service.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
 from datetime import datetime, UTC
+import json
+from pathlib import Path
+import zipfile
 
 from genai.brief_parser import slugify_campaign_name
 from genai.copy_generator import MockCampaignGenerator, get_campaign_generator
 from genai.image_generator import MockImageGenerator, get_image_generator
-from genai.schemas import CampaignBrief, CampaignManifest, ImageGenerationManifest, ImageGenerationRequest
+from genai.schemas import (
+    CampaignBrief,
+    CampaignManifest,
+    CampaignRegenerationRequest,
+    ImageGenerationManifest,
+    ImageGenerationRequest,
+    ImageReviewRequest,
+)
 from genai.storage import CampaignStorage
 
 
@@ -35,6 +45,44 @@ class CampaignBriefService:
 
     def list_campaigns(self) -> list[CampaignManifest]:
         return self.storage.list_campaigns()
+
+    def regenerate(self, campaign_id: str, request: CampaignRegenerationRequest | None = None) -> CampaignManifest:
+        existing = self.storage.load(campaign_id)
+        if existing is None:
+            raise ValueError("Campaign output not found")
+
+        generator = get_campaign_generator()
+        try:
+            output = generator.generate(existing.brief)
+            provider_name = generator.provider_name
+            mode = generator.mode
+        except Exception:
+            fallback = MockCampaignGenerator()
+            output = fallback.generate(existing.brief)
+            provider_name = fallback.provider_name
+            mode = "fallback-mock"
+
+        scope = request.scope if request else "all"
+        if scope == "copy":
+            for old_angle, new_angle in zip(existing.output.angles, output.angles):
+                old_angle.headlines = new_angle.headlines
+                old_angle.body_copy = new_angle.body_copy
+                old_angle.ctas = new_angle.ctas
+                old_angle.summary = new_angle.summary
+            existing.output.campaign_summary = output.campaign_summary
+            existing.output.audience_suggestions = output.audience_suggestions
+            existing.output.channel_recommendations = output.channel_recommendations
+            existing.output.tone_options = output.tone_options
+        elif scope == "prompts":
+            for old_angle, new_angle in zip(existing.output.angles, output.angles):
+                old_angle.image_prompts = new_angle.image_prompts
+        else:
+            existing.output = output
+
+        existing.provider = provider_name
+        existing.mode = mode
+        existing.updated_at = datetime.now(UTC).isoformat()
+        return self.storage.overwrite_campaign(existing)
 
 
 class CampaignImageService:
@@ -101,3 +149,62 @@ class CampaignImageService:
 
     def load_manifest(self, campaign_id: str) -> ImageGenerationManifest | None:
         return self.storage.load_image_manifest(campaign_id)
+
+    def review_asset(self, campaign_id: str, request: ImageReviewRequest) -> ImageGenerationManifest:
+        manifest = self.storage.load_image_manifest(campaign_id)
+        if manifest is None:
+            raise ValueError("Campaign image output not found")
+
+        updated = False
+        for asset in manifest.assets:
+            if asset.image_id == request.image_id:
+                asset.approval_status = request.approval_status
+                updated = True
+                break
+        if not updated:
+            raise ValueError("Image asset not found")
+
+        manifest.updated_at = datetime.now(UTC).isoformat()
+        return self.storage.save_image_manifest(manifest)
+
+
+class CampaignExportService:
+    def __init__(self, storage: CampaignStorage | None = None):
+        self.storage = storage or CampaignStorage()
+
+    def export_campaign(self, campaign_id: str) -> Path:
+        campaign = self.storage.load(campaign_id)
+        if campaign is None:
+            raise ValueError("Campaign output not found")
+
+        image_manifest = self.storage.load_image_manifest(campaign_id)
+        export_path = self.storage.export_zip_path(campaign_id)
+        prompt_payload = {
+            "campaign_id": campaign_id,
+            "angles": [
+                {
+                    "angle_id": angle.angle_id,
+                    "title": angle.title,
+                    "image_prompts": angle.image_prompts,
+                }
+                for angle in campaign.output.angles
+            ],
+        }
+
+        with zipfile.ZipFile(export_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr("brief.json", campaign.brief.model_dump_json(indent=2))
+            archive.writestr("copy.json", json.dumps(campaign.output.model_dump(mode="json"), indent=2))
+            archive.writestr("prompts.json", json.dumps(prompt_payload, indent=2))
+            archive.writestr("manifest.json", campaign.model_dump_json(indent=2))
+
+            if image_manifest is not None:
+                archive.writestr("images/manifest.json", image_manifest.model_dump_json(indent=2))
+                for asset in image_manifest.assets:
+                    asset_path = self.storage.repo_root / asset.file_path
+                    if asset_path.exists():
+                        archive.write(asset_path, arcname=f"images/{asset_path.name}")
+
+        campaign.artifacts.export_zip_path = str(export_path.relative_to(self.storage.repo_root))
+        campaign.updated_at = datetime.now(UTC).isoformat()
+        self.storage.overwrite_campaign(campaign)
+        return export_path

--- a/genai/storage.py
+++ b/genai/storage.py
@@ -15,21 +15,40 @@ class CampaignStorage:
         self.root = root or DEFAULT_GENERATED_ROOT
         self.repo_root = self.root.parents[1]
         self.copy_dir = self.root / "copy"
+        self.brief_dir = self.root / "briefs"
+        self.prompt_dir = self.root / "prompts"
         self.image_dir = self.root / "images"
         self.manifest_dir = self.root / "manifests"
-        for directory in (self.copy_dir, self.image_dir, self.manifest_dir):
+        self.export_dir = self.root / "exports"
+        for directory in (self.copy_dir, self.brief_dir, self.prompt_dir, self.image_dir, self.manifest_dir, self.export_dir):
             directory.mkdir(parents=True, exist_ok=True)
 
     def save(self, campaign_id: str, provider: str, mode: str, brief, output: CampaignOutput) -> CampaignManifest:
         copy_path = self.copy_dir / f"{campaign_id}.json"
+        brief_path = self.brief_dir / f"{campaign_id}.json"
+        prompts_path = self.prompt_dir / f"{campaign_id}.json"
         manifest_path = self.manifest_dir / f"{campaign_id}.json"
 
         payload = output.model_dump(mode="json")
         copy_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        brief_path.write_text(brief.model_dump_json(indent=2), encoding="utf-8")
+        prompts_payload = {
+            "campaign_id": campaign_id,
+            "angles": [
+                {
+                    "angle_id": angle.angle_id,
+                    "title": angle.title,
+                    "image_prompts": angle.image_prompts,
+                }
+                for angle in output.angles
+            ],
+        }
+        prompts_path.write_text(json.dumps(prompts_payload, indent=2), encoding="utf-8")
 
         manifest = CampaignManifest(
             campaign_id=campaign_id,
             created_at=datetime.now(UTC).isoformat(),
+            updated_at=datetime.now(UTC).isoformat(),
             provider=provider,
             mode=mode,
             brief=brief,
@@ -37,6 +56,8 @@ class CampaignStorage:
             artifacts=SavedArtifact(
                 manifest_path=str(manifest_path.relative_to(self.repo_root)),
                 copy_output_path=str(copy_path.relative_to(self.repo_root)),
+                brief_path=str(brief_path.relative_to(self.repo_root)),
+                prompts_path=str(prompts_path.relative_to(self.repo_root)),
             ),
         )
         manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
@@ -73,3 +94,28 @@ class CampaignStorage:
         if not manifest_path.exists():
             return None
         return ImageGenerationManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
+
+    def overwrite_campaign(self, manifest: CampaignManifest) -> CampaignManifest:
+        copy_path = self.copy_dir / f"{manifest.campaign_id}.json"
+        brief_path = self.brief_dir / f"{manifest.campaign_id}.json"
+        prompts_path = self.prompt_dir / f"{manifest.campaign_id}.json"
+        manifest_path = self.manifest_dir / f"{manifest.campaign_id}.json"
+        copy_path.write_text(json.dumps(manifest.output.model_dump(mode="json"), indent=2), encoding="utf-8")
+        brief_path.write_text(manifest.brief.model_dump_json(indent=2), encoding="utf-8")
+        prompts_payload = {
+            "campaign_id": manifest.campaign_id,
+            "angles": [
+                {
+                    "angle_id": angle.angle_id,
+                    "title": angle.title,
+                    "image_prompts": angle.image_prompts,
+                }
+                for angle in manifest.output.angles
+            ],
+        }
+        prompts_path.write_text(json.dumps(prompts_payload, indent=2), encoding="utf-8")
+        manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+        return manifest
+
+    def export_zip_path(self, campaign_id: str) -> Path:
+        return self.export_dir / f"{campaign_id}.zip"

--- a/run-demo.sh
+++ b/run-demo.sh
@@ -26,6 +26,7 @@ pushd "${ROOT_DIR}" >/dev/null
 "${PYTHON_BIN}" models/evaluate_model.py
 "${PYTHON_BIN}" -m genai.demo --input data/demo/campaign_brief.json
 "${PYTHON_BIN}" -m genai.image_demo --campaign-id "$(ls -1t data/generated/manifests/*.json | head -n 1 | xargs basename | sed 's/\.json$//')"
+"${PYTHON_BIN}" -m genai.export_demo --campaign-id "$(ls -1t data/generated/manifests/*.json | head -n 1 | xargs basename | sed 's/\.json$//')"
 
 LATEST_MODEL="$(ls -1t models/artifacts/models/trained_model_*.pkl | head -n 1)"
 LATEST_TRAIN_METRICS="$(ls -1t models/artifacts/models/trained_model_*_metrics.json | head -n 1)"
@@ -34,6 +35,7 @@ LATEST_GENAI_MANIFEST="$(ls -1t data/generated/manifests/*.json | head -n 1)"
 LATEST_GENAI_COPY="$(ls -1t data/generated/copy/*.json | head -n 1)"
 LATEST_GENAI_IMAGE_MANIFEST="$(ls -1t data/generated/images/*/manifest.json | head -n 1)"
 LATEST_GENAI_IMAGE_DIR="$(dirname "${LATEST_GENAI_IMAGE_MANIFEST}")"
+LATEST_GENAI_EXPORT="$(ls -1t data/generated/exports/*.zip | head -n 1)"
 
 cp "${LATEST_MODEL}" "${OUTPUT_DIR}/"
 cp "${LATEST_TRAIN_METRICS}" "${OUTPUT_DIR}/"
@@ -44,6 +46,7 @@ cp "${LATEST_GENAI_COPY}" "${OUTPUT_DIR}/genai/"
 mkdir -p "${OUTPUT_DIR}/genai/images"
 cp "${LATEST_GENAI_IMAGE_MANIFEST}" "${OUTPUT_DIR}/genai/images/"
 find "${LATEST_GENAI_IMAGE_DIR}" -maxdepth 1 \( -name '*.svg' -o -name '*.png' \) -exec cp {} "${OUTPUT_DIR}/genai/images/" \;
+cp "${LATEST_GENAI_EXPORT}" "${OUTPUT_DIR}/genai/"
 
 cat > "${OUTPUT_DIR}/README.txt" <<EOF
 CampaignForge AI Demo Output
@@ -58,13 +61,15 @@ Included files:
 - genai/$(basename "${LATEST_GENAI_COPY}")     saved campaign brief copy output
 - genai/images/$(basename "${LATEST_GENAI_IMAGE_MANIFEST}") latest image generation metadata
 - genai/images/*                                saved concept image assets
+- genai/$(basename "${LATEST_GENAI_EXPORT}")    exported campaign ZIP bundle
 
 Recommended next steps:
 1. Inspect the JSON metrics files in this folder.
 2. Inspect the generated campaign brief outputs in the genai/ folder.
 3. Inspect the saved image concepts in the genai/images/ folder.
-4. Run 'make api' to launch the FastAPI demo.
-5. Run 'make dashboard' to launch the Streamlit demo.
+4. Download or inspect the exported campaign ZIP in the genai/ folder.
+5. Run 'make api' to launch the FastAPI demo.
+6. Run 'make dashboard' to launch the Streamlit demo.
 EOF
 
 popd >/dev/null

--- a/scoring/fastapi_app.py
+++ b/scoring/fastapi_app.py
@@ -13,12 +13,20 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from genai.schemas import CampaignBrief, CampaignManifest, ImageGenerationManifest, ImageGenerationRequest
-from genai.service import CampaignBriefService, CampaignImageService
+from genai.schemas import (
+    CampaignBrief,
+    CampaignManifest,
+    CampaignRegenerationRequest,
+    ImageGenerationManifest,
+    ImageGenerationRequest,
+    ImageReviewRequest,
+)
+from genai.service import CampaignBriefService, CampaignExportService, CampaignImageService
 
 DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "processed" / "clean_marketing.csv"
 campaign_brief_service = CampaignBriefService()
 campaign_image_service = CampaignImageService()
+campaign_export_service = CampaignExportService()
 
 
 def _docs_enabled() -> bool:
@@ -121,12 +129,28 @@ def generate_campaign_images(request: ImageGenerationRequest) -> ImageGeneration
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@app.post("/genai/campaigns/{campaign_id}/regenerate", response_model=CampaignManifest)
+def regenerate_campaign_output(campaign_id: str, request: CampaignRegenerationRequest) -> CampaignManifest:
+    try:
+        return campaign_brief_service.regenerate(campaign_id, request)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @app.get("/genai/campaigns/{campaign_id}/images", response_model=ImageGenerationManifest)
 def get_campaign_images(campaign_id: str) -> ImageGenerationManifest:
     manifest = campaign_image_service.load_manifest(campaign_id)
     if manifest is None:
         raise HTTPException(status_code=404, detail="Campaign image output not found")
     return manifest
+
+
+@app.post("/genai/campaigns/{campaign_id}/images/review", response_model=ImageGenerationManifest)
+def review_campaign_image(campaign_id: str, request: ImageReviewRequest) -> ImageGenerationManifest:
+    try:
+        return campaign_image_service.review_asset(campaign_id, request)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @app.get("/genai/assets/{campaign_id}/{filename}")
@@ -137,3 +161,12 @@ def get_campaign_image_asset(campaign_id: str, filename: str) -> FileResponse:
         raise HTTPException(status_code=404, detail="Image asset not found")
     media_type = "image/png" if asset_path.suffix.lower() == ".png" else "image/svg+xml"
     return FileResponse(asset_path, media_type=media_type)
+
+
+@app.get("/genai/campaigns/{campaign_id}/export")
+def export_campaign_bundle(campaign_id: str) -> FileResponse:
+    try:
+        export_path = campaign_export_service.export_campaign(campaign_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return FileResponse(export_path, media_type="application/zip", filename=export_path.name)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import sys
+from typing import Optional
 
 # Add project root to sys.path for flexible imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".")))
@@ -17,8 +18,8 @@ except ModuleNotFoundError:
     st.stop()
 
 from airflow.scripts.mysql_utils import get_customers_data
-from genai.schemas import CampaignBrief, ImageGenerationRequest
-from genai.service import CampaignBriefService, CampaignImageService
+from genai.schemas import CampaignBrief, CampaignRegenerationRequest, ImageGenerationRequest, ImageReviewRequest
+from genai.service import CampaignBriefService, CampaignExportService, CampaignImageService
 from utils.crm_clients import HubSpotClient, SalesforceClient
 
 
@@ -27,6 +28,7 @@ st.session_state["title_rendered"] = True
 st.session_state["sidebar_initialized"] = True
 campaign_brief_service = CampaignBriefService()
 campaign_image_service = CampaignImageService()
+campaign_export_service = CampaignExportService()
 
 
 def render_styles():
@@ -107,6 +109,36 @@ def build_crm_records(dataframe: pd.DataFrame):
             }
         )
     return records
+
+
+def display_campaign_details(manifest):
+    st.markdown("**Campaign summary**")
+    st.write(manifest.output.campaign_summary)
+
+    st.markdown("**Audience suggestions**")
+    for persona in manifest.output.audience_suggestions:
+        st.markdown(f"- **{persona.name}**: {persona.description}")
+
+    st.markdown("**Channel recommendations**")
+    st.write(", ".join(manifest.output.channel_recommendations))
+
+    for angle in manifest.output.angles:
+        with st.expander(angle.title, expanded=False):
+            st.write(angle.summary)
+            st.markdown(f"**Tone:** {angle.tone}")
+            st.markdown(f"**Channels:** {', '.join(angle.recommended_channels)}")
+            st.markdown("**Headlines**")
+            for headline in angle.headlines:
+                st.markdown(f"- {headline}")
+            st.markdown("**Body copy**")
+            for body_copy in angle.body_copy:
+                st.markdown(f"- {body_copy}")
+            st.markdown("**CTAs**")
+            for cta in angle.ctas:
+                st.markdown(f"- {cta}")
+            st.markdown("**Image prompts**")
+            for prompt in angle.image_prompts:
+                st.code(prompt, language="text")
 
 
 def render_sidebar():
@@ -248,37 +280,68 @@ def render_genai_panel():
     manifest = campaign_brief_service.generate_and_save(brief_model)
     st.success(f"Generated campaign output: {manifest.campaign_id} ({manifest.mode})")
 
-    st.markdown("**Campaign summary**")
-    st.write(manifest.output.campaign_summary)
-
-    st.markdown("**Audience suggestions**")
-    for persona in manifest.output.audience_suggestions:
-        st.markdown(f"- **{persona.name}**: {persona.description}")
-
-    st.markdown("**Channel recommendations**")
-    st.write(", ".join(manifest.output.channel_recommendations))
-
-    for angle in manifest.output.angles:
-        with st.expander(angle.title, expanded=False):
-            st.write(angle.summary)
-            st.markdown(f"**Tone:** {angle.tone}")
-            st.markdown(f"**Channels:** {', '.join(angle.recommended_channels)}")
-            st.markdown("**Headlines**")
-            for headline in angle.headlines:
-                st.markdown(f"- {headline}")
-            st.markdown("**Body copy**")
-            for body_copy in angle.body_copy:
-                st.markdown(f"- {body_copy}")
-            st.markdown("**CTAs**")
-            for cta in angle.ctas:
-                st.markdown(f"- {cta}")
-            st.markdown("**Image prompts**")
-            for prompt in angle.image_prompts:
-                st.code(prompt, language="text")
+    display_campaign_details(manifest)
 
     st.caption(
         f"Saved manifest to {manifest.artifacts.manifest_path} and copy output to {manifest.artifacts.copy_output_path}."
     )
+
+
+def render_campaign_history_panel() -> Optional[object]:
+    st.markdown("---")
+    st.markdown('<div class="section-label">Campaign History</div>', unsafe_allow_html=True)
+    st.subheader("Reload, regenerate, and export saved campaigns")
+    campaigns = campaign_brief_service.list_campaigns()
+    if not campaigns:
+        st.info("No saved campaigns yet.")
+        return None
+
+    campaign_options = {
+        f"{campaign.campaign_id} | {campaign.brief.campaign_name or campaign.brief.product_name or 'Untitled campaign'}": campaign
+        for campaign in campaigns
+    }
+    selected_label = st.selectbox("Saved campaign history", list(campaign_options.keys()))
+    selected_campaign = campaign_options[selected_label]
+    st.caption(f"Created: {selected_campaign.created_at}")
+    if selected_campaign.updated_at:
+        st.caption(f"Last updated: {selected_campaign.updated_at}")
+
+    action_col1, action_col2, action_col3 = st.columns(3)
+    with action_col1:
+        if st.button("Regenerate copy", key=f"regen-copy-{selected_campaign.campaign_id}"):
+            selected_campaign = campaign_brief_service.regenerate(
+                selected_campaign.campaign_id,
+                CampaignRegenerationRequest(scope="copy"),
+            )
+            st.success("Campaign copy regenerated.")
+    with action_col2:
+        if st.button("Regenerate prompts", key=f"regen-prompts-{selected_campaign.campaign_id}"):
+            selected_campaign = campaign_brief_service.regenerate(
+                selected_campaign.campaign_id,
+                CampaignRegenerationRequest(scope="prompts"),
+            )
+            st.success("Campaign prompts regenerated.")
+    with action_col3:
+        if st.button("Build export ZIP", key=f"build-export-{selected_campaign.campaign_id}"):
+            export_path = campaign_export_service.export_campaign(selected_campaign.campaign_id)
+            st.session_state[f"export-path-{selected_campaign.campaign_id}"] = str(export_path)
+            st.success(f"Built export bundle: {export_path.name}")
+
+    export_path_value = st.session_state.get(f"export-path-{selected_campaign.campaign_id}")
+    if export_path_value:
+        export_path = Path(export_path_value)
+        if export_path.exists():
+            with open(export_path, "rb") as handle:
+                st.download_button(
+                    "Download campaign ZIP",
+                    data=handle.read(),
+                    file_name=export_path.name,
+                    mime="application/zip",
+                    key=f"export-{selected_campaign.campaign_id}",
+                )
+
+    display_campaign_details(selected_campaign)
+    return selected_campaign
 
 
 def render_image_generation_panel():
@@ -342,6 +405,29 @@ def render_image_generation_panel():
             else:
                 st.warning(f"Missing asset: {asset.file_path}")
             st.code(asset.prompt, language="text")
+            st.caption(f"Status: {asset.approval_status}")
+            approval_cols = st.columns(3)
+            with approval_cols[0]:
+                if st.button("Approve", key=f"approve-{asset.image_id}"):
+                    latest_manifest = campaign_image_service.review_asset(
+                        selected_campaign.campaign_id,
+                        ImageReviewRequest(image_id=asset.image_id, approval_status="approved"),
+                    )
+                    st.rerun()
+            with approval_cols[1]:
+                if st.button("Reject", key=f"reject-{asset.image_id}"):
+                    latest_manifest = campaign_image_service.review_asset(
+                        selected_campaign.campaign_id,
+                        ImageReviewRequest(image_id=asset.image_id, approval_status="rejected"),
+                    )
+                    st.rerun()
+            with approval_cols[2]:
+                if st.button("Reset", key=f"reset-{asset.image_id}"):
+                    latest_manifest = campaign_image_service.review_asset(
+                        selected_campaign.campaign_id,
+                        ImageReviewRequest(image_id=asset.image_id, approval_status="pending"),
+                    )
+                    st.rerun()
 
 
 def main():
@@ -351,6 +437,7 @@ def main():
     render_hero(dataframe)
     render_dataset_panel(dataframe, load_error)
     render_genai_panel()
+    render_campaign_history_panel()
     render_image_generation_panel()
     render_crm_panel(dataframe, crm_provider, dry_run)
 

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -89,3 +89,43 @@ def test_generate_campaign_images():
 def test_get_campaign_images_returns_404_when_missing():
     response = client.get("/genai/campaigns/does-not-exist/images")
     assert response.status_code == 404
+
+
+def test_review_and_export_campaign_workflow():
+    campaign_response = client.post(
+        "/genai/brief",
+        json={
+            "campaign_name": "Workflow API Launch",
+            "product_name": "CampaignForge AI",
+            "brief": "Create a workflow-ready campaign with approval and export support.",
+        },
+    )
+    campaign_id = campaign_response.json()["campaign_id"]
+    angle_id = campaign_response.json()["output"]["angles"][0]["angle_id"]
+
+    regenerate_response = client.post(
+        f"/genai/campaigns/{campaign_id}/regenerate",
+        json={"scope": "copy"},
+    )
+    assert regenerate_response.status_code == 200
+
+    image_response = client.post(
+        "/genai/images",
+        json={
+            "campaign_id": campaign_id,
+            "angle_id": angle_id,
+            "count": 1,
+        },
+    )
+    image_id = image_response.json()["assets"][0]["image_id"]
+
+    review_response = client.post(
+        f"/genai/campaigns/{campaign_id}/images/review",
+        json={"image_id": image_id, "approval_status": "approved"},
+    )
+    assert review_response.status_code == 200
+    assert review_response.json()["assets"][0]["approval_status"] == "approved"
+
+    export_response = client.get(f"/genai/campaigns/{campaign_id}/export")
+    assert export_response.status_code == 200
+    assert export_response.headers["content-type"].startswith("application/zip")

--- a/tests/test_genai_workflow_service.py
+++ b/tests/test_genai_workflow_service.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from genai.schemas import CampaignBrief, CampaignRegenerationRequest, ImageGenerationRequest, ImageReviewRequest
+from genai.service import CampaignBriefService, CampaignExportService, CampaignImageService
+from genai.storage import CampaignStorage
+
+
+def test_campaign_regeneration_and_export(tmp_path: Path):
+    storage = CampaignStorage(root=tmp_path / "data" / "generated")
+    brief_service = CampaignBriefService(storage=storage)
+    image_service = CampaignImageService(storage=storage)
+    export_service = CampaignExportService(storage=storage)
+
+    campaign = brief_service.generate_and_save(
+        CampaignBrief(
+            campaign_name="Workflow Demo",
+            product_name="CampaignForge AI",
+            brief="Create a reusable campaign workflow with copy, prompts, concept images, and export support.",
+        )
+    )
+
+    regenerated = brief_service.regenerate(campaign.campaign_id, CampaignRegenerationRequest(scope="copy"))
+    assert regenerated.updated_at is not None
+
+    image_manifest = image_service.generate_and_save(
+        ImageGenerationRequest(
+            campaign_id=campaign.campaign_id,
+            angle_id=campaign.output.angles[0].angle_id,
+            count=1,
+        )
+    )
+    reviewed = image_service.review_asset(
+        campaign.campaign_id,
+        ImageReviewRequest(image_id=image_manifest.assets[0].image_id, approval_status="approved"),
+    )
+    assert reviewed.assets[0].approval_status == "approved"
+
+    export_path = export_service.export_campaign(campaign.campaign_id)
+    assert export_path.exists()
+    assert export_path.suffix == ".zip"
+


### PR DESCRIPTION
Committed on codex/final-launch-prep:

b78c315d Finalize launch preparation docs
What I tightened:

README.md now leads more clearly with the actual shipped workflow:
Brief
Strategy
Copy
Image Concepts
Review
Export
added QA_CHECKLIST.md covering:
install
tests
demo
Streamlit
FastAPI
export
added concise RELEASE_NOTES.md for v1
updated RELEASE_CHECKLIST.md with stronger demo/doc/screenshots checks
updated docs/SCREENSHOT_CHECKLIST.md with exact screenshot and GIF moments to capture
updated docs/ASSET_PREP.md with a more sale-ready asset set
Repo hygiene review:

I checked tracked files for .DS_Store, venv, __pycache__, .pyc, dashboard/, and generated output clutter
no non-essential runtime artifacts are still tracked
the only tracked data/generated/* files are the intentional .gitkeep placeholders
Suggested exact screenshots / GIF:

README hero plus workflow section
make demo finished with demo_outputs/latest/ visible
Brief Copilot results with generated angles/copy visible
Image Concepts gallery with at least one approved asset
Campaign History panel with export control visible
FastAPI JSON response for /genai/brief or /health
20-30 second GIF:
select saved campaign
generate image concepts
approve one concept
build/download export ZIP
Verification:

python -m compileall streamlit_app.py scoring/fastapi_app.py genai passed
Only remaining launch items are mostly manual:

capture the actual screenshots/GIF into docs/assets/
update the public GitHub repo name/about text if needed
run the QA checklist on a machine with the full dependencies installed

6:39 PM
6 files changed
+161
-15
Undo

QA_CHECKLIST.md
+60
-0

README.md
+28
-0

RELEASE_CHECKLIST.md
+5
-0

RELEASE_NOTES.md
+31
-0

ASSET_PREP.md
+10
-7

SCREENSHOT_CHECKLIST.md
+27
-8