### PR TITLE
Fix PR checks and harden CI pipeline

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,19 +6,27 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: deploy-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+
 jobs:
   build-and-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: "pip"
@@ -31,28 +39,30 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt
 
       - name: Security audit (pip-audit)
-        run: |
-          pip install pip-audit
-          pip-audit -r requirements.txt
+        run: python -m pip_audit -r requirements.txt
 
       - name: Lint with flake8
         run: |
-          pip install flake8
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+          flake8 . --count --max-complexity=10 --max-line-length=100 --statistics
+
+      - name: Security scan with Bandit
+        run: |
+          bandit -q -r genai scoring utils etl models -x tests
 
   test:
     runs-on: ubuntu-latest
     needs: build-and-lint
+    timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: "pip"
@@ -65,19 +75,21 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt
 
       - name: Security audit (pip-audit)
-        run: |
-          pip install pip-audit
-          pip-audit -r requirements.txt
+        run: python -m pip_audit -r requirements.txt
 
-      - name: Run API and utility tests
+      - name: Run QA test suite
         run: |
           python -m pytest \
             tests/test_fastapi.py \
+            tests/test_genai_service.py \
+            tests/test_genai_image_service.py \
+            tests/test_genai_workflow_service.py \
             tests/test_prepare_data.py \
             tests/test_crm_clients.py \
+            tests/test_sheets_sync.py \
             --maxfail=1 \
             --disable-warnings \
             -q
@@ -86,12 +98,22 @@ jobs:
         run: |
           python -m pytest tests/test_streamlit.py --maxfail=1 --disable-warnings -q
 
+      - name: Run demo smoke check
+        run: |
+          ./run-demo.sh
+
+      - name: Validate demo outputs
+        run: |
+          test -f demo_outputs/latest/README.txt
+          find demo_outputs/latest/genai -maxdepth 2 -type f | sort
+
   docker-build:
     runs-on: ubuntu-latest
     needs: test
+    timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,5 +1,4 @@
 
-
 name: PR Continuous Integration
 
 on:
@@ -7,19 +6,27 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+
 jobs:
   pr-checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: "pip"
@@ -32,25 +39,35 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt
 
       - name: Security audit (pip-audit)
-        run: |
-          pip install pip-audit
-          pip-audit -r requirements.txt
+        run: python -m pip_audit -r requirements.txt
 
       - name: Run Linting
         run: |
-          pip install flake8
-          flake8 .
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --max-complexity=10 --max-line-length=100 --statistics
+
+      - name: Run Bandit
+        run: |
+          bandit -q -r genai scoring utils etl models -x tests
 
       - name: Run Tests
         run: |
           python -m pytest \
             tests/test_fastapi.py \
+            tests/test_genai_service.py \
+            tests/test_genai_image_service.py \
+            tests/test_genai_workflow_service.py \
             tests/test_prepare_data.py \
             tests/test_crm_clients.py \
+            tests/test_sheets_sync.py \
             tests/test_streamlit.py \
             --maxfail=1 \
             --disable-warnings \
             -q
+
+      - name: Run Demo Smoke Check
+        run: |
+          ./run-demo.sh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,6 @@
 
 # Local development and CI test tooling.
 pytest==8.4.2
+flake8==7.3.0
+pip-audit==2.9.0
+bandit[toml]==1.8.6

--- a/requirements-streamlit.txt
+++ b/requirements-streamlit.txt
@@ -9,3 +9,5 @@ pyarrow==22.0.0
 pymysql==1.1.1
 SQLAlchemy==2.0.44
 python-dotenv==1.0.1
+gspread==6.1.4
+google-auth==2.37.0

--- a/tests/test_sheets_sync.py
+++ b/tests/test_sheets_sync.py
@@ -1,12 +1,60 @@
-# tests/test_sheets_sync.py
 import pandas as pd
-from utils.sheets_sync import sync_to_google_sheets
-import streamlit as st
 
-def test_sync_to_sheets():
-    df = pd.DataFrame({
-        "customer_id": [1, 2],
-        "score": [0.87, 0.45]
-    })
-    success = sync_to_google_sheets(df, "Test_Scored_Customers", st.secrets["gcp_service_account"])
-    assert success
+from utils import sheets_sync
+
+
+class StubSheet:
+    def __init__(self):
+        self.cleared = False
+        self.updated_rows = None
+
+    def clear(self):
+        self.cleared = True
+
+    def update(self, rows):
+        self.updated_rows = rows
+
+
+class StubSpreadsheet:
+    def __init__(self, sheet):
+        self.sheet1 = sheet
+
+
+class StubClient:
+    def __init__(self, sheet):
+        self.sheet = sheet
+        self.created = None
+
+    def open(self, sheet_name):
+        return StubSpreadsheet(self.sheet)
+
+    def create(self, sheet_name):
+        self.created = sheet_name
+        return StubSpreadsheet(self.sheet)
+
+
+def test_sync_to_sheets(monkeypatch):
+    sheet = StubSheet()
+    client = StubClient(sheet)
+
+    monkeypatch.setattr(
+        sheets_sync.Credentials,
+        "from_service_account_info",
+        staticmethod(lambda payload: {"creds": payload}),
+    )
+    monkeypatch.setattr(sheets_sync.gspread, "authorize", lambda creds: client)
+
+    df = pd.DataFrame({"customer_id": [1, 2], "score": [0.87, 0.45]})
+    success = sheets_sync.sync_to_google_sheets(
+        df,
+        "Test_Scored_Customers",
+        {"type": "service_account"},
+    )
+
+    assert success is True
+    assert sheet.cleared is True
+    assert sheet.updated_rows[0] == ["customer_id", "score"]
+    assert sheet.updated_rows[1][0] == 1
+    assert sheet.updated_rows[1][1] == 0.87
+    assert sheet.updated_rows[2][0] == 2
+    assert sheet.updated_rows[2][1] == 0.45

--- a/utils/crm_clients.py
+++ b/utils/crm_clients.py
@@ -63,7 +63,12 @@ class SalesforceClient:
         endpoint = f"{self.instance_url}/services/data/{self.api_version}/composite/tree/Lead"
 
         if dry_run:
-            return {"sent": len(payload["records"]), "dry_run": True, "endpoint": endpoint, "payload": payload}
+            return {
+                "sent": len(payload["records"]),
+                "dry_run": True,
+                "endpoint": endpoint,
+                "payload": payload,
+            }
 
         if not self.instance_url or not self.access_token:
             raise RuntimeError("Salesforce credentials missing (SALESFORCE_INSTANCE_URL/SALESFORCE_ACCESS_TOKEN)")

--- a/utils/sheets_sync.py
+++ b/utils/sheets_sync.py
@@ -1,7 +1,9 @@
 import gspread
 from google.oauth2.service_account import Credentials
 
+
 def sync_to_google_sheets(df, sheet_name, credentials_dict):
+    """Sync a dataframe to a Google Sheet using a service account payload."""
     creds = Credentials.from_service_account_info(credentials_dict)
     client = gspread.authorize(creds)
 


### PR DESCRIPTION
Committed on codex/final-launch-prep:

43488e7c Fix PR checks and harden CI pipeline
What I fixed for the failing PR checks:

utils/crm_clients.py:
wrapped the long dry-run return payload to resolve E501
utils/sheets_sync.py:
added the missing blank line for E302
ensured the file ends with a newline for W292
added a short docstring
What I added for CI/CD security and QA:

requirements-dev.txt now includes:
flake8
pip-audit
bandit[toml]
requirements-streamlit.txt now includes:
gspread
google-auth
tests/test_sheets_sync.py is now fully mocked, so it no longer depends on live Streamlit secrets
GitHub Actions hardening in:
.github/workflows/pr-ci.yml
.github/workflows/deploy.yaml
Workflow improvements:

upgraded to newer actions/checkout / actions/setup-python
added permissions: contents: read
added workflow/job timeouts
standardized pip install flow
added bandit security scanning on app code
kept pip-audit
expanded test coverage to include:
GenAI service tests
image workflow tests
workflow/export tests
sheets sync tests
added demo smoke execution with ./run-demo.sh
added demo output validation in CI
Verification:

python -m compileall utils tests scoring genai streamlit_app.py passed locally
I still could not run pytest in this environment because pytest is not installed in the active interpreter here, but CI should now install it via requirements-dev.txt
Most likely result:

the exact flake8 failures you pasted should be resolved
the PR checks should now run a stronger pipeline with actual QA and security checks instead of only minimal lint/test steps
If you push this branch and the PR still has a failing check, send me that next failure and I’ll keep narrowing it down.


7:14 PM
7 files changed
+136
-37
Undo

deploy.yaml
pr-ci.yml
requirements-dev.txt
requirements-streamlit.txt
test_sheets_sync.py
crm_clients.py
sheets_sync.py
